### PR TITLE
Remove unused dexie type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@playwright/test": "^1.42.1",
     "@testing-library/react": "^14.2.1",
-    "@types/dexie": "^3.2.5",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",


### PR DESCRIPTION
## Summary
- remove the @types/dexie entry from package.json devDependencies since it is no longer needed

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hookform%2fresolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68e2328373d883249577e6e772c18a83