### PR TITLE
Add Radix UI themes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/themes": "^2.0.0",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^4.36.1",


### PR DESCRIPTION
## Summary
- add the `@radix-ui/themes` package to the dependencies list so it is available alongside the other Radix UI libraries

## Testing
- npm install *(fails: 403 Forbidden when fetching packages from registry)*
- npm run dev *(fails: vite binary unavailable before dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e236794d1883248a92e81f8ff2831e