### PR TITLE
chore: remove proxy settings from npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
 registry=https://registry.npmjs.org/
 @radix-ui:registry=https://registry.npmjs.org/
-proxy=http://proxy:8080
-https-proxy=http://proxy:8080
-strict-ssl=false
+# proxy configuration removed; set HTTP(S)_PROXY env vars locally if needed
+# proxy=http://proxy:8080
+# https-proxy=http://proxy:8080
+# strict-ssl=false


### PR DESCRIPTION
## Summary
- comment out the proxy, https-proxy, and strict-ssl settings in the root .npmrc and document using local environment variables instead

## Testing
- `env -u npm_config_http_proxy -u npm_config_https_proxy -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u YARN_HTTP_PROXY -u YARN_HTTPS_PROXY npm ci --no-progress` *(fails: ENETUNREACH contacting registry.npmjs.org)*
- `npm run build` *(fails: vite missing because dependencies could not be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68e25036ccf8832488820b69ead2d73e